### PR TITLE
修复 upyun_bucket_domain 选项处理错误

### DIFF
--- a/lib/carrierwave/storage/upyun.rb
+++ b/lib/carrierwave/storage/upyun.rb
@@ -136,7 +136,7 @@ module CarrierWave
           puts "DEPRECATION: upyun_bucket_domain config is deprecated, please use upyun_bucket_host to insead."
 
           bucket_host = @uploader.upyun_bucket_domain
-          bucket_host.prepend('http://') if bucket_host.match(/^http/)
+          bucket_host.prepend('http://') unless bucket_host.match(/^http/)
           [bucket_host, @path].join("/")
         end
 


### PR DESCRIPTION
修复 upyun_bucket_domain 选项处理错误，并重构了代码

以下 Commit 实现有问题，前缀处理错了

https://github.com/nowa/carrierwave-upyun/commit/59e2d1457688797c2d7119ccabe2a2e87f05ce32

``` ruby
["http://",@uploader.upyun_bucket_domain, @path].join("/") #=> http:///example.com/path
```
