### PR TITLE
add size method to avoid recreate_versions error

### DIFF
--- a/lib/carrierwave/storage/upyun/file.rb
+++ b/lib/carrierwave/storage/upyun/file.rb
@@ -104,6 +104,17 @@ module CarrierWave::Storage
       end
 
       ##
+      # Return size of file body
+      #
+      # === Returns
+      #
+      # [Integer] size of file body
+      #
+      def size
+        headers['content-length'].to_i
+      end
+
+      ##
       # Writes the supplied data into the object on Cloud Files.
       #
       # === Returns


### PR DESCRIPTION
在重建versions时遇到了一个bug。
#### 问题描述：
调用 `lib/carrierwave/uploader/cache.rb`中 cache! 方法 时：

```
      def cache!(new_file = file)
        new_file = CarrierWave::SanitizedFile.new(new_file)
        return if new_file.empty?
        ……
      end
```
发现 new_file.empty? 返回 true，其中 file 是 上传的upyun文件。

随后查看`lib/carrierwave/sanitized_file.rb`，发现是因为upyun 未定义 size method, 导致 size 返回0，故new_file.empty?  返回true。
```
    def size
      if is_path?
        exists? ? File.size(path) : 0
      elsif @file.respond_to?(:size)
        @file.size
      elsif path
        exists? ? File.size(path) : 0
      else
        0
      end
    end
```
在`file.rb`中添加 size method后，问题解决。